### PR TITLE
Add end_user validation

### DIFF
--- a/app/controllers/end_users/registrations_controller.rb
+++ b/app/controllers/end_users/registrations_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class EndUsers::RegistrationsController < Devise::RegistrationsController
-  # before_action :configure_sign_up_params, only: [:create]
+  before_action :configure_sign_up_params, only: [:create]
   # before_action :configure_account_update_params, only: [:update]
 
   # GET /resource/sign_up

--- a/app/controllers/public/end_users_controller.rb
+++ b/app/controllers/public/end_users_controller.rb
@@ -1,2 +1,6 @@
 class Public::EndUsersController < Public::Base
+  private
+  def end_user_params
+   	params.require(:end_user).permit(:family_name, :first_name, :family_name_kana, :first_name_kana, :email, :postal_code, :address, :phone_number, :is_deleted)
+  end
 end

--- a/app/models/end_user.rb
+++ b/app/models/end_user.rb
@@ -3,4 +3,8 @@ class EndUser < ApplicationRecord
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
+
+  validates :family_name, :first_name, :postal_code, :address, :phone_number, presence: true
+  # 全角カナ入力のバリデーション
+  validates :family_name_kana, :first_name_kana, presence: true, format: { with: /\A[\p{katakana}\p{blank}ー－]+\z/}
 end

--- a/app/views/end_users/registrations/new.html.erb
+++ b/app/views/end_users/registrations/new.html.erb
@@ -15,8 +15,8 @@
           </div>
 
           <div class="form-group">
-            <strong class="col-sm-2">フリガナ</strong>
-            <%= f.label :family_name_kana, '(セイ)', class:"col-sm-1 col-sm-offset-2" %>
+            <strong class="col-sm-3">フリガナ（全角カナ）</strong>
+            <%= f.label :family_name_kana, '(セイ)', class:"col-sm-1 col-sm-offset-1" %>
             <%= f.text_field :family_name_kana, autofocus: true, autocomplete: "family_name_kana", class:"col-sm-3" %>
             <%= f.label :first_name_kana, '(メイ)', class:"col-sm-1" %>
             <%= f.text_field :first_name_kana, autofocus: true, autocomplete: "first_name_kana", class:"col-sm-3" %>


### PR DESCRIPTION
## 変更点
### end_users.controller
- end_user_paramsの追記
### end_user.model
- 顧客登録のvalidation記述
- 全角カナ入力のvalidation記述
### registration view
- 振り仮名を全角カナで入力してもらうよう記述追加
### registration.controller
- sign_upの際のパラメーター追記