### PR TITLE
Public/cart items

### DIFF
--- a/app/controllers/public/cart_items_controller.rb
+++ b/app/controllers/public/cart_items_controller.rb
@@ -1,12 +1,19 @@
 class Public::CartItemsController < Public::Base
   def index
     @cart_items = CartItem.where(end_user_id: current_end_user.id)
-    @total_price = 0
+    @subtotal_price = 0 #ビューで使う変数の初期化
   end
 
   def create
+    #同じ商品がカートに入っているか検索
+    existing_cart_item = CartItem.find_by(end_user_id: current_end_user.id, item_id: cart_item_params[:item_id])
+
     @cart_item = CartItem.new(cart_item_params)
-    if @cart_item.save
+    if existing_cart_item #同じ商品がカートに入っていたら個数を上書きする
+      existing_cart_item.quantity = @cart_item.quantity
+      existing_cart_item.save
+      redirect_to cart_items_path
+    elsif @cart_item.save
       redirect_to cart_items_path
     else
       flash[:alert] = "Please select a number"

--- a/app/controllers/public/cart_items_controller.rb
+++ b/app/controllers/public/cart_items_controller.rb
@@ -1,2 +1,46 @@
 class Public::CartItemsController < Public::Base
+  def index
+    @cart_items = CartItem.where(end_user_id: current_end_user.id)
+    @total_price = 0
+  end
+
+  def create
+    @cart_item = CartItem.new(cart_item_params)
+    if @cart_item.save
+      redirect_to cart_items_path
+    else
+      flash[:alert] = "Please select a number"
+      redirect_back(fallback_location: root_path)
+    end
+  end
+
+  def update
+    @cart_item = CartItem.find(params[:id])
+    if @cart_item.update(cart_item_params)
+      redirect_to cart_items_path
+    else
+      render :index
+    end
+  end
+
+  def destroy
+    cart_item = CartItem.find(params[:id])
+    if cart_item.end_user_id == current_end_user.id
+      cart_item.destroy
+      redirect_to cart_items_path
+    else
+      render :index
+    end
+  end
+
+  def destroy_all
+    cart_items = CartItem.where(end_user_id: current_end_user.id)
+    cart_items.destroy_all
+    redirect_to cart_items_path
+  end
+
+  private
+  def cart_item_params
+    params.require(:cart_item).permit(:item_id, :end_user_id, :quantity)
+  end
 end

--- a/app/models/cart_item.rb
+++ b/app/models/cart_item.rb
@@ -1,2 +1,10 @@
 class CartItem < ApplicationRecord
+  validates :quantity, numericality: {only_integer: true}
+
+  belongs_to :end_user
+  belongs_to :item
+
+  def sub_total
+    BigDecimal(self.item.price) * BigDecimal("1.1") * BigDecimal(self.quantity)
+  end
 end

--- a/app/models/end_user.rb
+++ b/app/models/end_user.rb
@@ -3,4 +3,6 @@ class EndUser < ApplicationRecord
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
+
+  has_many :cart_items
 end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -5,7 +5,7 @@ class Item < ApplicationRecord
   validates :sales_status, inclusion: {in: [true, false]}
 
   belongs_to :genre
-  has_many :cart_item
+  has_many :cart_items
   attachment :image
 
   def price_with_tax

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -5,6 +5,7 @@ class Item < ApplicationRecord
   validates :sales_status, inclusion: {in: [true, false]}
 
   belongs_to :genre
+  has_many :cart_item
   attachment :image
 
   def price_with_tax

--- a/app/views/public/cart_items/index.html.erb
+++ b/app/views/public/cart_items/index.html.erb
@@ -1,0 +1,51 @@
+<div class="container">
+  <div class="row">
+    <h4>ショッピングカート</h4>
+    <%= link_to "カートを空にする", cart_items_destroy_all_path, class: "btn btn-danger", method: :delete %>
+  </div>
+  <table class="table table-hover table-inverse table-bordered">
+    <thead>
+      <tr>
+        <th>商品名</th>
+        <th>単価（税込）</th>
+        <th>数量</th>
+        <th>小計</th>
+        <th></th>
+      </tr>
+    </thead>
+    <tbody>
+      <% @cart_items.each do |cart_item| %>
+        <tr>
+          <td>
+            <%= attachment_image_tag cart_item.item, :image, :fill, 90, 60, fallback: "no_image.jpg", size: '90x60' %>
+            <%= cart_item.item.name %>
+          </td>
+          <td><%= cart_item.item.price_with_tax %></td>
+          <td>
+            <%= form_for(cart_item) do |f| %>
+              <%= f.number_field :quantity %>
+              <%= f.submit "変更", class: "btn btn-primary" %>
+            <% end %>
+          </td>
+          <td><%= cart_item.sub_total.ceil.to_s(:delimited) %></td>
+          <td><%= link_to "削除する", cart_item_path(cart_item), class: "btn btn-danger", method: :delete %></td>
+        </tr>
+        <% @total_price += cart_item.sub_total %>
+      <% end %>
+    </tbody>
+  </table>
+  <div class="col-xs-2">
+    <%= link_to "買い物を続ける", root_path, class: "btn btn-primary" %>
+  </div>
+  <div class="col-xs-2">
+    <table class="table table-hover table-inverse table-bordered">
+      <tbody>
+        <tr>
+          <td>合計金額</td>
+          <td><%= @total_price.ceil.to_s(:delimited) %></td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+  <%= link_to "情報入力に進む", new_order_path, class: "btn btn-success" %>
+</div>

--- a/app/views/public/cart_items/index.html.erb
+++ b/app/views/public/cart_items/index.html.erb
@@ -23,14 +23,14 @@
           <td><%= cart_item.item.price_with_tax %></td>
           <td>
             <%= form_for(cart_item) do |f| %>
-              <%= f.number_field :quantity %>
+              <%= f.select :quantity, (1..30) %>
               <%= f.submit "変更", class: "btn btn-primary" %>
             <% end %>
           </td>
           <td><%= cart_item.sub_total.ceil.to_s(:delimited) %></td>
           <td><%= link_to "削除する", cart_item_path(cart_item), class: "btn btn-danger", method: :delete %></td>
         </tr>
-        <% @total_price += cart_item.sub_total %>
+        <% @subtotal_price += cart_item.sub_total %>
       <% end %>
     </tbody>
   </table>
@@ -42,10 +42,10 @@
       <tbody>
         <tr>
           <td>合計金額</td>
-          <td><%= @total_price.ceil.to_s(:delimited) %></td>
+          <td><%= @subtotal_price.ceil.to_s(:delimited) %></td>
         </tr>
       </tbody>
     </table>
   </div>
-  <%= link_to "情報入力に進む", new_order_path, class: "btn btn-success" %>
+  <%= link_to "情報入力に進む", new_order_path, class: "btn btn-success", subtotal_price: @subtotal_price %>
 </div>

--- a/app/views/public/items/_errors.html.erb
+++ b/app/views/public/items/_errors.html.erb
@@ -1,0 +1,5 @@
+<% if flash[:alert] %>
+  <div id="error_explanation">
+    <%= flash[:alert] %>
+  </div>
+<% end %>

--- a/app/views/public/items/show.html.erb
+++ b/app/views/public/items/show.html.erb
@@ -25,6 +25,7 @@
     <% if end_user_signed_in? && @item.sales_status == true %>
       <div class="row">
         <%= form_for(@cart_item) do |f| %>
+          <%= render 'public/items/errors', model: f.object %>
           <%= f.select :quantity, (1..30), {include_blank: "個数選択"} %>
           <%= f.hidden_field :item_id, value: @item.id %>
           <%= f.hidden_field :end_user_id, value: current_end_user.id %>


### PR DESCRIPTION
## 変更点
- public/cart_itemsコントローラーに各アクション追加
  - createアクションでは同じ商品がカートに入っていた場合、個数を変更しcart_itemsインスタンスを作成しないよう変更
- cart_item, item, end_userモデルでそれぞれ関連付け追加
- cart_itemモデルに各商品の小計を求めるsub_totalメソッドを追加
- indexページを作成
  - 情報入力にすすむボタンを押したときに商品合計金額をパラメーターで渡すよう定義
- 商品詳細ページで個数を選択せずにカートに入れるボタンを押したときにエラーが出るように修正