### PR TITLE
[Fix]order

### DIFF
--- a/app/controllers/public/orders_controller.rb
+++ b/app/controllers/public/orders_controller.rb
@@ -17,28 +17,10 @@ class Public::OrdersController < Public::Base
   	if current_end_user.cart_items.exists?
       @order = Order.new(order_params)
       @order.end_user_id = current_end_user.id
-      @order.postage = Order::POSTAGE
-      # Orederモデルで定義
-
-      # 住所のラジオボタン選択に応じて引数を調整
-      @add = params[:order][:add].to_i
-      case @add
-        when 1
-          @order.postal_code = current_end_user.postal_code
-          @order.address = current_end_user.address
-          @order.name = full_name(current_end_user)
-        when 2
-          @order.postal_code = params[:order][:postal_code]
-          @order.address = params[:order][:address]
-          @order.name = params[:order][:name]
-        when 3
-          @order.postal_code = params[:order][:postal_code]
-          @order.address = params[:order][:address]
-          @order.name = params[:order][:name]
-      end
+      @order.postage = Order::POSTAGE # Orederモデルで定義
       @order.save
 
-       # send_to_addressで住所モデル検索、該当データなければ新規作成
+       # ShippingAddressで住所モデル検索、該当データなければ新規作成
       if ShippingAddress.find_by(address: @order.address).nil?
         @address = ShippingAddress.new
         @address.postal_code = @order.postal_code

--- a/app/models/shipping_address.rb
+++ b/app/models/shipping_address.rb
@@ -4,4 +4,8 @@ class ShippingAddress < ApplicationRecord
   validates :name, presence: true
 
   belongs_to :end_user
+
+  def postal_code_address_name
+    self.postal_code + "　" + self.address + "　" + self.name
+  end
 end

--- a/app/views/public/orders/confirm.html.erb
+++ b/app/views/public/orders/confirm.html.erb
@@ -1,75 +1,64 @@
 <div class="container">
-  <div class="row">
-    <div class="col-lg-10">
+  <div class="col-xs-12">
     <h2>注文情報確認</h2>
+  </div>
 
     <%= form_with(model: @order, local: true) do |f| %>
 
-      <div class="row">
-        <div class="col-lg-8">
-          <table class="table-bordered">
-            <thead>
-              <tr>
-                <th><h4>商品名</h4></th>
-                <th><h4>単価（税込）</h4></th>
-                <th><h4>数量</h4></th>
-                <th><h4>小計</h4></th>
-              </tr>
-            </thead>
-            <tbody>
-              <% sum_all = 0 %>
-              <% @cart_items.each do |cart_item| %>
-                <tr>
-                  <td><%= attachment_image_tag cart_item.item, :image, :fill, 40, 40, fallback: "no_image.jpg", :size => '80x60' %>
-                  <%= cart_item.item.name %></td>
-                  <th><%= cart_item.item.price_with_tax %></th>
-                  <th><%= cart_item.quantity %></th>
-                  <th><%= cart_item.sub_total.ceil.to_s(:delimited) %></th>
-                </tr>
-                <% sum_all += cart_item.sub_total %>
-              <% end %>
-            </tbody>
-          </table>
-        </div>
-      </div>
-
-　    <div class="row">
-        <div class="col-lg-4">
-          <table class="table-bordered">
-            <tr>
-              <th>送料</th>
-              <th><%= Order::POSTAGE %>円</th>
-            </tr>
-            <tr>
-              <th>商品合計</th>
-              <th><%= sum_all.ceil.to_s(:delimited) %></th>
-            </tr>
-            <tr>
-              <th>請求金額</th>
-              <th><% subtotal_price = sum_all + @order.postage.to_i %>
-                <%= subtotal_price.ceil.to_s(:delimited) %></th>
-            </tr>
-          </table>
-        </div>
-      </div>
-    </div>
+  <div class="col-xs-8">
+    <table class="table-bordered">
+      <thead>
+        <tr>
+          <th><h4>商品名</h4></th>
+          <th><h4>単価（税込）</h4></th>
+          <th><h4>数量</h4></th>
+          <th><h4>小計</h4></th>
+        </tr>
+      </thead>
+      <tbody>
+        <% sum_all = 0 %>
+        <% @cart_items.each do |cart_item| %>
+          <tr>
+            <td><%= attachment_image_tag cart_item.item, :image, :fill, 40, 40, fallback: "no_image.jpg", :size => '80x60' %>
+              <%= cart_item.item.name %></td>
+            <th><%= cart_item.item.price_with_tax %></th>
+            <th><%= cart_item.quantity %></th>
+            <th><%= cart_item.sub_total.ceil.to_s(:delimited) %></th>
+          </tr>
+          <% sum_all += cart_item.sub_total %>
+        <% end %>
+      </tbody>
+    </table>
   </div>
 
-  <div class="row space-sm">
-    <h3>支払方法</h3>
-      <div class="col-lg-4">
-        <%= @order.payment_method %>
-      </div>
-    </div>
+  <div class="col-xs-4">
+    <table class="table-bordered">
+      <tr>
+        <th>送料</th>
+        <th><%= Order::POSTAGE %></th>
+      </tr>
+      <tr>
+        <th>商品合計</th>
+        <th><%= sum_all.ceil.to_s(:delimited) %></th>
+      </tr>
+      <tr>
+        <th>請求金額</th>
+        <th><% subtotal_price = sum_all + Order::POSTAGE %>
+                <%= subtotal_price.ceil.to_s(:delimited) %></th>
+      </tr>
+    </table>
+  </div>
 
-    <div class="row space-sm">
-      <h3>お届け先</h3>
-      <div class="col-lg-4">
-        <%= @order.postal_code %>
-        <%= @order.address %>
-        <%= @order.name %>
-      </div>
-    </div>
+  <div class="col-xs-12">
+    <h3>支払方法</h3>
+    <%= @order.payment_method %>
+  </div>
+  <div class="col-xs-12">
+    <h3>お届け先</h3>
+    <%= @order.postal_code %>
+    <%= @order.address %>
+    <%= @order.name %>
+  </div>
 
     <%= f.hidden_field :end_user_id, :value => current_end_user.id %>
     <%= f.hidden_field :postal_code, :value => "#{@order.postal_code}" %>
@@ -78,11 +67,8 @@
     <%= f.hidden_field :subtotal_price, :value => sum_all %>
     <%= f.hidden_field :payment_method, :value => @order.payment_method %>
 
-    <div class="row space">
-      <div class="col-lg-2 offset-lg-5">
-        <%= f.submit "購入を確定する", class: "btn btn-success active" %>
-     </div>
-    </div>
+  <div class="col-xs-4">
+    <%= f.submit "購入を確定する", class: "btn btn-success active" %>
   </div>
   <% end %>
 </div>

--- a/app/views/public/orders/confirm.html.erb
+++ b/app/views/public/orders/confirm.html.erb
@@ -1,92 +1,88 @@
-<div class="col-lg-10">
+<div class="container">
   <div class="row">
+    <div class="col-lg-10">
     <h2>注文情報確認</h2>
-  </div>
 
-  <%= form_with(model: @order, local: true) do |f| %>
+    <%= form_with(model: @order, local: true) do |f| %>
 
-  <div class="row">
-    <div class="col-lg-8">
-      <table class="table-bordered">
-        <thead>
-          <tr>
-            <th><h4>商品名</h4></th>
-            <th><h4>単価（税込）</h4></th>
-            <th><h4>数量</h4></th>
-            <th><h4>小計</h4></th>
-          </tr>
-        </thead>
-        <tbody>
-          <% sum_all = 0 %>
-          <% @cart_items.each do |cart_item| %>
+      <div class="row">
+        <div class="col-lg-8">
+          <table class="table-bordered">
+            <thead>
+              <tr>
+                <th><h4>商品名</h4></th>
+                <th><h4>単価（税込）</h4></th>
+                <th><h4>数量</h4></th>
+                <th><h4>小計</h4></th>
+              </tr>
+            </thead>
+            <tbody>
+              <% sum_all = 0 %>
+              <% @cart_items.each do |cart_item| %>
+                <tr>
+                  <td><%= attachment_image_tag cart_item.item, :image, :fill, 40, 40, fallback: "no_image.jpg", :size => '80x60' %>
+                  <%= cart_item.item.name %></td>
+                  <th><%= cart_item.item.price_with_tax %></th>
+                  <th><%= cart_item.quantity %></th>
+                  <th><%= cart_item.sub_total.ceil.to_s(:delimited) %></th>
+                </tr>
+                <% sum_all += cart_item.sub_total %>
+              <% end %>
+            </tbody>
+          </table>
+        </div>
+      </div>
+
+　    <div class="row">
+        <div class="col-lg-4">
+          <table class="table-bordered">
             <tr>
-              
-              <td><%= cart_item.item.name %></td>
-              <th><%= cart_item.item.price_with_tax %></th>
-              <th><%= cart_item.quantity %></th>
-              <th><%= cart_item.sub_total.ceil.to_s(:delimited) %></th>
+              <th>送料</th>
+              <th><%= Order::POSTAGE %>円</th>
             </tr>
-            <% sum_all += cart_item.sub_total %>
-          <% end %>
-        </tbody>
-      </table>
-    </div>
-  </div>
-
-  <div class="col-lg-4">
-    <table class="table-bordered">
-      <tr>
-        <th>送料</th>
-        <th><%= Order::POSTAGE %>円</th>
-      </tr>
-      <tr>
-        <th>商品合計</th>
-        <th><%= sum_all.ceil.to_s(:delimited) %></th>
-      </tr>
-      <tr>
-        <th>請求金額</th>
-        <th><% subtotal_price = sum_all + @order.postage.to_i %>
-          <%= subtotal_price.ceil.to_s(:delimited) %></th>
-      </tr>
-    </table>
-  </div>
-
-
-
-  <div class="row space-sm">
-    <div class="col-lg-2">
-      <h3>支払方法</h3>
-    </div>
-    <div class="col-lg-4">
-      <%= @order.payment_method %>
+            <tr>
+              <th>商品合計</th>
+              <th><%= sum_all.ceil.to_s(:delimited) %></th>
+            </tr>
+            <tr>
+              <th>請求金額</th>
+              <th><% subtotal_price = sum_all + @order.postage.to_i %>
+                <%= subtotal_price.ceil.to_s(:delimited) %></th>
+            </tr>
+          </table>
+        </div>
+      </div>
     </div>
   </div>
 
   <div class="row space-sm">
-    <div class="col-lg-2">
+    <h3>支払方法</h3>
+      <div class="col-lg-4">
+        <%= @order.payment_method %>
+      </div>
+    </div>
+
+    <div class="row space-sm">
       <h3>お届け先</h3>
+      <div class="col-lg-4">
+        <%= @order.postal_code %>
+        <%= @order.address %>
+        <%= @order.name %>
+      </div>
     </div>
-    <div class="col-lg-4">
-      <%= @order.postal_code %>
-      <%= @order.address %>
-      <%= @order.name %>
+
+    <%= f.hidden_field :end_user_id, :value => current_end_user.id %>
+    <%= f.hidden_field :postal_code, :value => "#{@order.postal_code}" %>
+    <%= f.hidden_field :address, :value => "#{@order.address}" %>
+    <%= f.hidden_field :name, :value => "#{@order.name}" %>
+    <%= f.hidden_field :subtotal_price, :value => sum_all %>
+    <%= f.hidden_field :payment_method, :value => @order.payment_method %>
+
+    <div class="row space">
+      <div class="col-lg-2 offset-lg-5">
+        <%= f.submit "購入を確定する", class: "btn btn-success active" %>
+     </div>
     </div>
   </div>
-
-  <%= f.hidden_field :end_user_id, :value => current_end_user.id %>
-  <%= f.hidden_field :postal_code, :value => "#{@order.postal_code}" %>
-  <%= f.hidden_field :address, :value => "#{@order.address}" %>
-  <%= f.hidden_field :name, :value => "#{@order.name}" %>
-  <%= f.hidden_field :subtotal_price, :value => sum_all %>
-  <%= f.hidden_field :payment_method, :value => @order.payment_method %>
-</div>
-
-<div class="row space">
-  <div class="col-lg-2 offset-lg-5">
-    <%= f.submit "購入を確定する", class: "btn btn-success active" %>
-  </div>
-</div>
-
-
-<% end %>
+  <% end %>
 </div>

--- a/app/views/public/orders/new.html.erb
+++ b/app/views/public/orders/new.html.erb
@@ -9,12 +9,9 @@
   <div class="row">
     <h2><strong><%= f.label :支払方法 %></strong></h2>
     <div class="col-lg-4">
-      <label class="btn btn-outline-secondary active" style="width:50%">
         <%= f.radio_button :payment_method, 0, {checked: true} %> クレジットカード
-      </label>
-      <label class="btn btn-outline-secondary" style="width:50%">
+      <br>
         <%= f.radio_button :payment_method, 1, {} %> 銀行振込
-      </label>
     </div>
   </div>
 
@@ -26,11 +23,11 @@
         <label><%= f.radio_button :add, 1, checked: true, checked: "checked" %>ご自身の住所</label><br>
         <%= current_end_user.postal_code %>
         <%= current_end_user.address %>
-        <%= current_end_user.family_name %><%= current_end_user.first_name %>
+        <%= current_end_user.family_name %> <%= current_end_user.first_name %>
       </p>
       <p>
-        <label><%= f.radio_button :add, 2, style: "display: inline-block" %>登録住所から選択</label><br>
-        <%= f.collection_select :address, current_end_user.shipping_addresses, :id, :address %>
+        <label><%= f.radio_button :add, 2, style: "display: inline-block" %>登録済住所から選択</label><br>
+        <%= f.collection_select :address, current_end_user.shipping_addresses, :id, :postal_code_address_name %>
       </p>
       <p><label><%= f.radio_button :add, 3 %>新しいお届け先</label></p>
       <div class="row">


### PR DESCRIPTION
## 更新点

- 支払い方法、配送先選択画面で新規の配送先を選択したときに、住所録の方にも登録されるのを確認

- 支払い方法、配送先選択画面の見え方を修正

- ShippingAddressモデルに郵便番号＋住所＋名前を一度に表示するメソッド定義

- 注文確認画面の並びを修正