### PR TITLE
Add top page item ranking

### DIFF
--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -1,7 +1,7 @@
 class HomeController < ApplicationController
   def top
   	@genres = Genre.where(is_active: true)
-    #注文のあった商品を売上金額順のに表示
+    #注文のあった商品を売上金額順に表示
     @items = Item.find(OrderItem.group(:item_id).order("sum(ordering_price) desc").limit(4).pluck(:item_id))
     #テスト対策 まだどの商品も売れてない場合はID順で4つ表示
     if @items.count == 0

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -1,7 +1,12 @@
 class HomeController < ApplicationController
   def top
   	@genres = Genre.where(is_active: true)
-  	@items = Item.limit(4)
+    #注文のあった商品を売上金額順のに表示
+    @items = Item.find(OrderItem.group(:item_id).order("sum(ordering_price) desc").limit(4).pluck(:item_id))
+    #テスト対策 まだどの商品も売れてない場合はID順で4つ表示
+    if @items.count == 0
+      @items = Item.limit(4)
+    end
   end
 
   def about

--- a/app/views/home/top.html.erb
+++ b/app/views/home/top.html.erb
@@ -16,10 +16,12 @@
 			</div>
 
 			<!-- オススメ商品の表示 -->
+      <% rank = 1 %>
 			<div class="recommendation">
 			<h2 class="recommendation-head"><strong>オススメ商品</strong></h2>
 			<% @items.each do |item| %>
       			<div class="item-wrapper">
+              <p><strong><%= rank %>位</strong></p>
         			<%= link_to item_path(item) do %>
           				<div class="item-image">
             			<%= attachment_image_tag item, :image, :fill, 150, 100, fallback: "no_image.jpg", size: '150x100' %>
@@ -30,6 +32,7 @@
           				</div>
         			<% end %>
       			</div>
+            <% rank += 1 %>
     		<% end %>
     		<div class="col-xs-9 col-xs-offset-9">
     			<%= link_to 'もっと見る>', items_path %>

--- a/app/views/public/end_users/show.html.erb
+++ b/app/views/public/end_users/show.html.erb
@@ -36,11 +36,11 @@
       </table>
     </div>
 
-    <div class="col-xs-12 user-info">
+    <div class="col-xs-12 user-info shipping_addresses">
       <strong style="font-size: 18px;" class="col-xs-2">配送先</strong>
       <%= link_to "一覧を見る", shipping_addresses_path, class:"btn btn-primary" %>
     </div>
-    <div class="col-xs-12 user-info">
+    <div class="col-xs-12 user-info orders">
       <strong style="font-size: 18px;" class="col-xs-2">注文一覧</strong>
       <%= link_to "一覧を見る", orders_path, class:"btn btn-primary" %>
     </div>


### PR DESCRIPTION
# 変更点
* トップページのオススメ商品を売上金額順に表示するよう変更
* オススメ商品に順位を表示
参考URL：https://qiita.com/hitochan/items/258215ec62ead338c2eb
<img width="1119" alt="スクリーンショット_2020-09-13_14_11_05" src="https://user-images.githubusercontent.com/66856295/93010792-1eac5c80-f5cb-11ea-956f-fcfd13a862df.png">
